### PR TITLE
fix(css): restore list markers (bullets/numbers) in post content

### DIFF
--- a/src/components/Layout/layout.css
+++ b/src/components/Layout/layout.css
@@ -251,6 +251,29 @@ li > ol {
   margin-bottom: 0;
 }
 
+/*
+ * Restore list markers.
+ * Tailwind's Preflight (loaded via `@import 'tailwindcss'`) sets
+ * `list-style: none` on all ul/ol, which removes bullets/numbers.
+ * Re-enable them for content lists.
+ */
+.post-content ul {
+  list-style: disc;
+  padding-left: 1.5em;
+}
+
+.post-content ol {
+  list-style: decimal;
+  padding-left: 1.5em;
+}
+
+/* Lists that intentionally have no markers (previously relied on Preflight) */
+.post-content .related-posts ul,
+.post-content .uses-list {
+  list-style: none;
+  padding-left: 0;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
Bullet points in blog posts, /uses, and /links pages were invisible after Tailwind CSS v4 was introduced.

**Root cause:** Tailwind's Preflight reset applies `list-style: none` globally on all ul/ol, removing the disc/decimal markers. Custom CSS only added `margin-left: 1em` (creating the visible indent) without restoring `list-style`, so the indent appeared but no symbol was visible.

**Fix:** Restore list markers within `.post-content` (covers all rendered article text), and explicitly mark the two lists that rely on the no-bullet state (related-posts, uses-list) so the fix doesn't leak into them.

**Scope/behavior impact:**
- Blog post markdown lists & links page lists now show bullets/numbers
- Related posts and /uses lists remain bullet-less (appearance unchanged)
- Table of contents, tag lists, post-list, etc. unaffected